### PR TITLE
Improve channel parsing and filtered list naming

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "midnite-archive"
 version = "0.2.0"
 edition = "2024"
+rust-version = "1.85"
 
 [dependencies]
 anyhow = "1.0.102"

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ just ci-pin    # Pin GitHub Actions to SHAs
 
 - [Requirements](docs/requirements.md) - Setup and installation guide
 - [CLI UX Spec](docs/cli-ux.md) - Output contract, paths, and command summaries
+- [yt-dlp Rust Integration](docs/yt-dlp-integration.md) - Wrapper options and migration criteria
 - [Troubleshooting](docs/troubleshooting.md) - Common issues and solutions
 - [Processing Comments](docs/processing-comments.md) - YouTube comment data extraction
 - [tmux](docs/tmux.md) - Running long downloads in background

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ just ci-pin    # Pin GitHub Actions to SHAs
 ## Documentation
 
 - [Requirements](docs/requirements.md) - Setup and installation guide
+- [CLI UX Spec](docs/cli-ux.md) - Output contract, paths, and command summaries
 - [Troubleshooting](docs/troubleshooting.md) - Common issues and solutions
 - [Processing Comments](docs/processing-comments.md) - YouTube comment data extraction
 - [tmux](docs/tmux.md) - Running long downloads in background

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ midnite-archive <COMMAND>
 # Generate channel list
 midnite-archive generate @severo12
 
+# Generate filtered list (title regex via yt-dlp --match-title)
+midnite-archive generate @severo12 --filter live
+
 # Download from list file
 midnite-archive download severo12/lists/severo12-list-url-*.txt
 

--- a/docs/cli-ux.md
+++ b/docs/cli-ux.md
@@ -1,0 +1,143 @@
+# CLI UX Spec
+
+Contract for how `midnite-archive` talks to the user: stdout vs logs, path layout, and per-command success output.
+
+This is a product/UX spec for the CLI, not a dump of tracing logs. Verbose `INFO` lines belong behind `-v`; default runs should stay short and actionable.
+
+## Principles
+
+1. **Quiet by default.** Without `-v`, print only what the user needs next (counts, paths, status).
+2. **Verbose is opt-in.** `-v` / `-vv` / `-vvv` enable tracing (`info` / `debug` / `trace`). Progress chatter stays there.
+3. **Errors are explicit.** Failures go to stderr as `Error: …` and exit non-zero.
+4. **Artifacts are printed.** When a command creates files the user will pass to another command, print those paths on stdout.
+5. **One summary style.** Prefer a leading `✓` line, then indented detail lines. Avoid mixing unrelated ornaments.
+
+## Global flags
+
+| Flag | Behavior |
+|------|----------|
+| `-v` | `INFO` tracing |
+| `-vv` | `DEBUG` tracing |
+| `-vvv` | `TRACE` tracing |
+| (none) | tracing off unless `RUST_LOG` is set |
+
+## On-disk layout
+
+Per channel (handle or `UC…` id as directory name):
+
+```text
+{channel}/
+  lists/      # generate output
+  videos/     # download output (+ .archive/)
+  comments/   # comments output
+```
+
+### List file naming
+
+```text
+{channel}-list-title[-filtered]-{YYYYMMDDHHMMSS}.txt
+{channel}-list-url[-filtered]-{YYYYMMDDHHMMSS}.txt
+```
+
+- `-filtered` is present only when `--filter` was used.
+- Title file: yt-dlp flat-playlist lines (`title-id`).
+- URL file: one `https://www.youtube.com/watch?v=…` per line.
+
+Channel names may contain hyphens (`foo-bar`). Downstream commands recover the channel from the filename by splitting on `-list`.
+
+## Commands
+
+### `generate`
+
+**Input:** handle (`severo12`), `@handle`, `https://www.youtube.com/@handle`, or `https://www.youtube.com/channel/UC…`.
+
+**Options:**
+
+| Option | Meaning |
+|--------|---------|
+| `--filter REGEX` | Passed to yt-dlp `--match-title` (title regex, not `--match-filter` syntax) |
+
+**Default success (stdout):**
+
+```text
+✓ 412 videos
+  Title: severo12/lists/severo12-list-title-20260403023745.txt
+  URLs: severo12/lists/severo12-list-url-20260403023745.txt
+```
+
+**Filtered success (stdout):**
+
+```text
+$ midnite-archive generate @nomotrouble123 --filter midnite
+✓ Filter 'midnite' applied - 233 videos
+  Title: nomotrouble123/lists/nomotrouble123-list-title-filtered-20260403023745.txt
+  URLs: nomotrouble123/lists/nomotrouble123-list-url-filtered-20260403023745.txt
+```
+
+With `-v`, also expect channel resolution, fetch progress, and parse counts as `INFO` lines.
+
+### `download`
+
+**Input:** a list file path, or a single `http(s)` YouTube URL.
+
+**Layout:**
+
+- List file → `{channel}/videos/` with `.archive/{list-stem}.archive`
+- Single URL → `downloads/` with `.archive/downloads.archive`
+
+**Default success (stdout) for list downloads:**
+
+```text
+📊 Download Statistics:
+   Total videos: 233
+   Already downloaded: 10
+   Remaining to download: 223
+
+✓ Downloaded 5 new video(s) this session
+   Progress: 15/233 videos complete
+✓ Done!
+```
+
+Single-URL runs may only print `✓ Done!`.
+
+### `comments`
+
+**Input:** a URL list file.
+
+**Layout:** `{channel}/comments/` (`%(id)s.comments.json`).
+
+**Default success (stdout):**
+
+```text
+✓ Done!
+```
+
+With `-v`, expect list parsing and per-video previews as `INFO` lines.
+
+### `rename`
+
+**Input:** a directory of media/sidecar files.
+
+**Options:** `-d/--dry-run`, `-r/--recursive`, `-e/--extensions`.
+
+**Behavior notes:**
+
+- Dry-run builds a source → renamed table.
+- Today the table is emitted via tracing (`INFO`), so **dry-run is easiest to see with `-v`** until stdout is unified.
+
+## Error shape
+
+```text
+Error: <message>
+```
+
+Exit code `1`. Prefer actionable messages (missing yt-dlp/deno, bad path, invalid channel).
+
+## Consistency backlog
+
+Tracked here so future CLI changes stay aligned with this spec:
+
+- [ ] Make `download` / `comments` summaries as informative as `generate` (paths + counts on stdout by default).
+- [ ] Print `rename` dry-run table on stdout (not only via `-v` tracing).
+- [ ] Align status ornaments (`✓` vs stats emoji) under one style.
+- [ ] Prefer channel display without forcing `@` when the input is a `UC…` channel id.

--- a/docs/yt-dlp-integration.md
+++ b/docs/yt-dlp-integration.md
@@ -1,0 +1,155 @@
+# yt-dlp Rust Integration
+
+Research note for replacing the direct `std::process::Command` calls in
+`src/yt_dlp.rs` with a maintained Rust API while keeping yt-dlp as the download
+engine.
+
+## Goals
+
+- Preserve yt-dlp's broad site support and frequent upstream fixes.
+- Move subprocess orchestration, JSON metadata, and progress handling behind a
+  typed asynchronous Rust API.
+- Keep one `midnite-archive` binary for the CLI and a future TUI.
+- Retain the current features: channel lists, title filters, download archives,
+  comments, EJS/Deno arguments, metadata, thumbnails, and custom output paths.
+- Prepare for Linux, macOS, and Windows releases.
+
+Neither candidate is a pure-Rust replacement for yt-dlp. Both wrap the yt-dlp
+executable. That is desirable here: replacing yt-dlp's extractors would make
+midnite-archive responsible for tracking frequent platform changes.
+
+## Candidates
+
+### `yt-dlp` (`boul2gom/yt-dlp`)
+
+- Crate: <https://crates.io/crates/yt-dlp>
+- Source: <https://github.com/boul2gom/yt-dlp>
+- Reviewed version: `2.7.2`
+- License: `GPL-3.0-only`
+
+An asynchronous, feature-rich yt-dlp and ffmpeg wrapper. It can download both
+executables automatically, exposes generic and YouTube-specific extractors, and
+offers structured metadata, download hooks, caches, retries, and format
+selection.
+
+**Strengths**
+
+- Manages yt-dlp and ffmpeg installation.
+- Generic extractor supports sites beyond YouTube.
+- YouTube-specific channel, handle, playlist, and search APIs.
+- Hooks and statistics are useful foundations for a future TUI.
+- Active releases and a relatively broad API.
+
+**Concerns**
+
+- GPL-3.0-only is strong copyleft. Distributing a binary that links this crate
+  requires midnite-archive to use GPL-compatible terms and provide corresponding
+  source.
+- The abstraction is large and brings features midnite-archive may not need.
+- Current midnite-archive behavior depends on low-level yt-dlp flags
+  (`--download-archive`, `--write-comments`, `--match-title`,
+  `--remote-components`, and `--js-runtimes`). API parity must be proven before
+  migration.
+- Adopting its downloader API would couple the application closely to one
+  wrapper.
+
+### `ytd-rs`
+
+- Crate: <https://crates.io/crates/ytd-rs>
+- Source: <https://github.com/narrrl/ytd-rs>
+- Reviewed version: `0.2.1`
+- License: repository README states `MIT`; crates.io reports the license field
+  as non-standard, so package metadata should be clarified upstream before
+  adoption.
+
+A smaller asynchronous wrapper with a builder API, structured metadata, custom
+yt-dlp argument passthrough, line-by-line process output, and binary streaming.
+yt-dlp must already be available on `PATH`.
+
+**Strengths**
+
+- Custom arguments preserve access to all current yt-dlp features.
+- Streaming process output is a direct path to CLI and TUI progress events.
+- Small API and dependency footprint.
+- MIT terms are compatible with a permissively licensed midnite-archive, once
+  the crates.io metadata discrepancy is resolved.
+- Keeps dependency installation separate from download orchestration.
+
+**Concerns**
+
+- Does not manage yt-dlp or ffmpeg installation.
+- Much smaller project and ecosystem than yt-dlp itself.
+- Version `0.2.x` indicates a young API with potential breaking changes.
+- Progress is raw yt-dlp output; midnite-archive must parse it into stable,
+  typed events.
+- Automatic EJS/Deno setup and all current archive/comments workflows need
+  integration tests.
+
+## Comparison
+
+| Requirement | `boul2gom/yt-dlp` | `ytd-rs` |
+|-------------|-------------------|----------|
+| Async API | Yes | Yes |
+| Structured metadata | Yes | Yes |
+| Generic sites | Yes | Via yt-dlp arguments |
+| Raw argument passthrough | Must be verified | Yes |
+| Progress foundation | Typed hooks | Streamed output lines |
+| Installs yt-dlp/ffmpeg | Yes | No |
+| Current archive/comments parity | Must be proven | Likely via custom args; must be proven |
+| License impact | Requires GPL-compatible project distribution | MIT stated upstream; metadata needs confirmation |
+| Integration size | Larger, opinionated API | Smaller wrapper |
+
+## Recommendation
+
+Start with a time-boxed integration spike for `ytd-rs`, behind a
+midnite-archive-owned backend boundary. It best preserves the current yt-dlp
+flags, offers progress streaming for a future TUI, and avoids committing the
+whole project to GPL before API fit is known.
+
+Do not expose either crate's types from the CLI or domain modules. Define
+midnite-archive request, result, and progress types, then adapt the selected
+crate internally:
+
+```text
+CLI / future TUI
+        |
+        v
+midnite-archive service API
+        |
+        v
+YtDlpBackend
+        |
+        +-- ytd-rs (preferred spike)
+        |
+        +-- boul2gom/yt-dlp (fallback evaluation)
+```
+
+The `boul2gom/yt-dlp` crate remains the fallback if the spike shows that
+automatic dependency management or typed hooks materially outweigh the GPL
+licensing impact.
+
+## Spike acceptance criteria
+
+The preferred candidate must demonstrate all of the following before replacing
+`src/yt_dlp.rs`:
+
+1. Generate a flat channel list and apply `--match-title`.
+2. Download a single URL and a batch file with the existing output template.
+3. Preserve `--download-archive` behavior.
+4. Download comments without media.
+5. Pass EJS remote components and the Deno runtime.
+6. Surface cancellation-safe, line-by-line progress suitable for both CLI and
+   future TUI consumers.
+7. Produce actionable errors with subprocess exit status and stderr.
+8. Work with externally installed yt-dlp/ffmpeg on Linux, with a documented
+   path for macOS and Windows packaging.
+9. Confirm the selected crate's license metadata and compatibility before
+   merging the dependency.
+
+## Out of scope
+
+- Replacing yt-dlp's extractors with a pure-Rust YouTube implementation.
+- Adding the TUI itself.
+- Shipping a second binary.
+- Implementing automatic dependency installation before the wrapper choice is
+  validated.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["clippy", "rustfmt"]

--- a/src/cli/comments.rs
+++ b/src/cli/comments.rs
@@ -24,18 +24,9 @@ pub fn execute(list_file: &Path) -> Result<()> {
 
     tracing::debug!("Checking if {} directory exists...", list_file.channel.name);
 
-    if !list_file.channel.base_dir().exists() {
-        fs::create_dir_all(&comments_dir)
-            .with_context(|| format!("Failed to create directory: {:?}", comments_dir))?;
-        tracing::info!("Directory created: {}", list_file.channel.name);
-    } else {
-        fs::create_dir_all(&comments_dir)
-            .with_context(|| format!("Failed to create directory: {:?}", comments_dir))?;
-        tracing::info!(
-            "{} directory already exists, creating comments directory...",
-            list_file.channel.name
-        );
-    }
+    fs::create_dir_all(&comments_dir)
+        .with_context(|| format!("Failed to create directory: {:?}", comments_dir))?;
+    tracing::info!("Comments directory ready: {}", comments_dir.display());
 
     let file_stem = list_file
         .path

--- a/src/cli/generate.rs
+++ b/src/cli/generate.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use chrono::Local;
 use std::fs::{self, File};
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub fn execute(channel_input: &str, filter: Option<&str>) -> Result<()> {
     tracing::info!("Generating video list for: {}", channel_input);
@@ -17,18 +17,13 @@ pub fn execute(channel_input: &str, filter: Option<&str>) -> Result<()> {
     let channel_name = ChannelName::parse(channel_input)?;
     let channel = Channel::new(channel_name);
 
-    tracing::info!("YouTube channel name: @{}", channel.name);
+    tracing::info!("YouTube channel: {}", channel.name);
     tracing::info!("YouTube channel url: {}", channel.url());
 
     let timestamp = get_timestamp();
     let list_dir = channel.lists_dir();
-
-    let base_name = format!("{}-list-{}", channel.name, timestamp);
-    let title_file = list_dir.join(format!(
-        "{}.txt",
-        base_name.replacen("list", "list-title", 1)
-    ));
-    let url_file = list_dir.join(format!("{}.txt", base_name.replacen("list", "list-url", 1)));
+    let (title_file, url_file) =
+        list_output_paths(&list_dir, channel.name.as_ref(), filter, &timestamp);
 
     tracing::info!("Generating output files...");
     tracing::debug!("Title file: {}", title_file.display());
@@ -75,6 +70,24 @@ fn get_timestamp() -> String {
     Local::now().format("%Y%m%d%H%M%S").to_string()
 }
 
+/// Build title/url list paths, adding `-filtered` when a filter is set.
+fn list_output_paths(
+    list_dir: &Path,
+    channel_name: &str,
+    filter: Option<&str>,
+    timestamp: &str,
+) -> (PathBuf, PathBuf) {
+    let filtered_suffix = if filter.is_some() { "-filtered" } else { "" };
+    let file_prefix = format!("{channel_name}-list-");
+
+    let title_file = list_dir.join(format!(
+        "{file_prefix}title{filtered_suffix}-{timestamp}.txt"
+    ));
+    let url_file = list_dir.join(format!("{file_prefix}url{filtered_suffix}-{timestamp}.txt"));
+
+    (title_file, url_file)
+}
+
 fn generate_url_file(videos: &[Video], url_file: &PathBuf) -> Result<()> {
     let mut output = File::create(url_file)
         .with_context(|| format!("Failed to create URL file: {:?}", url_file))?;
@@ -86,4 +99,45 @@ fn generate_url_file(videos: &[Video], url_file: &PathBuf) -> Result<()> {
     tracing::debug!("Written {} URLs to {}", videos.len(), url_file.display());
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_paths_without_filter() {
+        let (title, url) = list_output_paths(
+            Path::new("severo12/lists"),
+            "severo12",
+            None,
+            "20240101120000",
+        );
+        assert_eq!(
+            title,
+            PathBuf::from("severo12/lists/severo12-list-title-20240101120000.txt")
+        );
+        assert_eq!(
+            url,
+            PathBuf::from("severo12/lists/severo12-list-url-20240101120000.txt")
+        );
+    }
+
+    #[test]
+    fn list_paths_with_filter() {
+        let (title, url) = list_output_paths(
+            Path::new("foo-bar/lists"),
+            "foo-bar",
+            Some("live"),
+            "20240101120000",
+        );
+        assert_eq!(
+            title,
+            PathBuf::from("foo-bar/lists/foo-bar-list-title-filtered-20240101120000.txt")
+        );
+        assert_eq!(
+            url,
+            PathBuf::from("foo-bar/lists/foo-bar-list-url-filtered-20240101120000.txt")
+        );
+    }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -28,7 +28,7 @@ pub enum Commands {
     Generate {
         /// YouTube channel (e.g., @severo12, severo12, or channel URL)
         channel: String,
-        /// Filter videos by title pattern (e.g., --filter "live" or --filter "title*=live")
+        /// Filter videos by title regex (passed to yt-dlp --match-title)
         #[arg(short, long)]
         filter: Option<String>,
     },

--- a/src/types.rs
+++ b/src/types.rs
@@ -129,7 +129,11 @@ impl Channel {
     }
 
     pub fn url(&self) -> String {
-        format!("https://www.youtube.com/@{}", self.name)
+        if self.name.is_channel_id() {
+            format!("https://www.youtube.com/channel/{}", self.name)
+        } else {
+            format!("https://www.youtube.com/@{}", self.name)
+        }
     }
 
     /// Get the base directory for this channel
@@ -171,16 +175,25 @@ impl ChannelName {
         }
     }
 
-    /// Parse from various input formats (URL, @name, or plain name)
+    /// Parse from various input formats (handle URL, channel ID URL, @name, or plain name)
     pub fn parse(input: &str) -> Result<Self> {
-        let re = Regex::new(r"/@([^/]+)").unwrap();
-        let name = if let Some(caps) = re.captures(input) {
+        let handle_re = Regex::new(r"/@([^/?#]+)").unwrap();
+        let channel_id_re = Regex::new(r"/channel/(UC[A-Za-z0-9_-]{22})").unwrap();
+
+        let name = if let Some(caps) = handle_re.captures(input) {
+            caps[1].to_string()
+        } else if let Some(caps) = channel_id_re.captures(input) {
             caps[1].to_string()
         } else {
             input.strip_prefix('@').unwrap_or(input).to_string()
         };
 
         Self::new(name)
+    }
+
+    /// YouTube channel IDs are 24 characters starting with "UC"
+    pub fn is_channel_id(&self) -> bool {
+        self.0.len() == 24 && self.0.starts_with("UC")
     }
 
     /// Check if a string is a valid channel name
@@ -234,17 +247,34 @@ impl ListFile {
         })
     }
 
-    /// Extract channel name from list file path
+    /// Extract channel name from list file path.
+    ///
+    /// Expected patterns (optional `.txt` suffix):
+    /// - `{channel}-list-url[-filtered]-{timestamp}`
+    /// - `{channel}-list-title[-filtered]-{timestamp}`
+    /// - `{channel}-list[-filtered]-{timestamp}`
     fn extract_channel_from_path(path: &Path) -> Result<Channel> {
         let file_name = path
             .file_name()
             .and_then(|n| n.to_str())
             .context("Failed to extract filename from path")?;
 
-        let channel_name = file_name
-            .split('-')
-            .next()
-            .context("Failed to extract channel name from filename")?;
+        let stem = file_name.strip_suffix(".txt").unwrap_or(file_name);
+
+        let channel_name = if let Some(idx) = stem.find("-list") {
+            &stem[..idx]
+        } else {
+            stem.split('-')
+                .next()
+                .context("Failed to extract channel name from filename")?
+        };
+
+        if channel_name.is_empty() {
+            bail!(
+                "Failed to extract channel name from filename: {}",
+                file_name
+            );
+        }
 
         let name = ChannelName::new(channel_name)?;
         Ok(Channel::new(name))
@@ -310,7 +340,8 @@ impl ListFile {
     /// Parse a video from a YouTube URL
     fn parse_video_from_url(url: &str, channel: &Channel) -> Option<Video> {
         // Match watch?v= format
-        let watch_regex = Regex::new(&format!(r"youtube\.com/watch\?v=({VIDEO_ID_PATTERN})")).unwrap();
+        let watch_regex =
+            Regex::new(&format!(r"youtube\.com/watch\?v=({VIDEO_ID_PATTERN})")).unwrap();
         if let Some(caps) = watch_regex.captures(url)
             && let Ok(id) = VideoId::from_str(&caps[1])
         {
@@ -378,6 +409,23 @@ mod tests {
 
         let plain = ChannelName::parse("testchannel").unwrap();
         assert_eq!(plain.to_string(), "testchannel");
+
+        let from_channel_id_url =
+            ChannelName::parse("https://www.youtube.com/channel/UCzVYPvtfWW349M7KyHmVmtA").unwrap();
+        assert_eq!(from_channel_id_url.to_string(), "UCzVYPvtfWW349M7KyHmVmtA");
+        assert!(from_channel_id_url.is_channel_id());
+    }
+
+    #[test]
+    fn test_channel_url_for_handle_and_id() {
+        let handle = Channel::new(ChannelName::new("severo12").unwrap());
+        assert_eq!(handle.url(), "https://www.youtube.com/@severo12");
+
+        let id = Channel::new(ChannelName::new("UCzVYPvtfWW349M7KyHmVmtA").unwrap());
+        assert_eq!(
+            id.url(),
+            "https://www.youtube.com/channel/UCzVYPvtfWW349M7KyHmVmtA"
+        );
     }
 
     #[test]
@@ -559,5 +607,29 @@ mod tests {
 
         let (videos, _) = list_file.read_videos().unwrap();
         assert_eq!(videos[0].channel.name.to_string(), "mychannel");
+    }
+
+    #[test]
+    fn test_extract_channel_from_hyphenated_list_filename() {
+        let dir = tempfile::tempdir().unwrap();
+        let list_file = create_test_list_file(
+            dir.path(),
+            "foo-bar-list-url-20240101120000.txt",
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ\n",
+        );
+
+        assert_eq!(list_file.channel.name.to_string(), "foo-bar");
+    }
+
+    #[test]
+    fn test_extract_channel_from_filtered_list_filename() {
+        let dir = tempfile::tempdir().unwrap();
+        let list_file = create_test_list_file(
+            dir.path(),
+            "severo12-list-url-filtered-20240101120000.txt",
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ\n",
+        );
+
+        assert_eq!(list_file.channel.name.to_string(), "severo12");
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens channel handling, finishes filtered-list naming from #32, and documents the CLI UX and yt-dlp wrapper direction.

### Fixes
- Parse hyphenated channel names by splitting list filenames on `-list`.
- Support `/channel/UC...` URLs and emit the correct channel URL form.

### Improvements
- Add `-filtered` to generated title/URL list names when `--filter` is used, with tests.
- Clarify that `--filter` is passed to yt-dlp `--match-title`.
- Add stable Rust toolchain and edition-2024 MSRV metadata.
- Simplify comments-directory setup.

### Documentation
- [`docs/cli-ux.md`](docs/cli-ux.md): stdout/logging contract, paths, naming, command examples, and consistency backlog.
- [`docs/yt-dlp-integration.md`](docs/yt-dlp-integration.md): focused comparison of the two candidate Rust wrappers:
  - `boul2gom/yt-dlp` — broad API, binary management, typed hooks, GPL-3.0-only.
  - `ytd-rs` — small async wrapper, arbitrary argument passthrough, streamed output, MIT stated upstream (crates.io metadata needs clarification).
- Recommends a `ytd-rs` spike behind a project-owned backend boundary and defines acceptance criteria for feature parity, progress, errors, EJS/Deno, and cross-platform packaging.

### Verification
- 25 unit tests pass.
- Clippy passes with warnings denied.
- Documentation diff passes whitespace validation.

### Follow-ups
- Close #32 as superseded after this lands.
- Create implementation issues from the integration spike criteria.
- Finish or remove the stub YouTube channel-list workflow.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f18082df-6672-48af-b0f9-533207b4f4a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f18082df-6672-48af-b0f9-533207b4f4a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

