### PR TITLE
chore(just): add mise upgrade dry-run and apply recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ just lint              # Run clippy
 just fmt               # Format code
 just ci-scan           # Security audit workflows
 just ci-pin            # Pin GitHub Actions to SHAs
-just mise-upgrade-dry  # Preview mise tool upgrades
-just mise-upgrade      # Apply mise tool upgrades
+just mise-upgrade-dry  # Preview local mise.toml tool upgrades
+just mise-upgrade      # Apply local mise.toml tool upgrades
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -72,14 +72,16 @@ midnite-archive rename severo12/videos
 ## Development
 
 ```shell
-just build     # Build debug binary
-just release   # Build optimized binary
-just check     # Check compilation
-just test      # Run tests
-just lint      # Run clippy
-just fmt       # Format code
-just ci-scan   # Security audit workflows
-just ci-pin    # Pin GitHub Actions to SHAs
+just build             # Build debug binary
+just release           # Build optimized binary
+just check             # Check compilation
+just test              # Run tests
+just lint              # Run clippy
+just fmt               # Format code
+just ci-scan           # Security audit workflows
+just ci-pin            # Pin GitHub Actions to SHAs
+just mise-upgrade-dry  # Preview mise tool upgrades
+just mise-upgrade      # Apply mise tool upgrades
 ```
 
 ## Documentation

--- a/justfile
+++ b/justfile
@@ -49,13 +49,13 @@ alias t := mise-tools
 @mise-tools:
     mise ls --json | jq -r --arg pwd "$(pwd)" 'to_entries[] | select(.value[].source.path != null and (.value[].source.path | contains($pwd))) | .key'
 
-# Preview mise tool upgrades (no changes)
+# Preview local mise.toml tool upgrades (no changes)
 @mise-upgrade-dry:
-    mise upgrade --dry-run
+    mise upgrade --local --dry-run
 
-# Apply mise tool upgrades from mise.toml
+# Apply tool upgrades from local mise.toml only
 @mise-upgrade:
-    mise upgrade
+    mise upgrade --local
 
 # List GitHub Actions workflows
 @workflows:

--- a/justfile
+++ b/justfile
@@ -49,6 +49,14 @@ alias t := mise-tools
 @mise-tools:
     mise ls --json | jq -r --arg pwd "$(pwd)" 'to_entries[] | select(.value[].source.path != null and (.value[].source.path | contains($pwd))) | .key'
 
+# Preview mise tool upgrades (no changes)
+@mise-upgrade-dry:
+    mise upgrade --dry-run
+
+# Apply mise tool upgrades from mise.toml
+@mise-upgrade:
+    mise upgrade
+
 # List GitHub Actions workflows
 @workflows:
     gh workflow list --json name --jq "to_entries[] | .value.name"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Just recipes for previewing and applying **local** mise tool upgrades only (`mise.toml`), not global config.

### Changes
- `just mise-upgrade-dry` → `mise upgrade --local --dry-run`
- `just mise-upgrade` → `mise upgrade --local`
- Documented both in the README Development section

### Usage
```shell
just mise-upgrade-dry   # preview local uninstall/install plan
just mise-upgrade       # apply upgrades from project mise.toml only
```

No changes to `mise.toml` itself.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f18082df-6672-48af-b0f9-533207b4f4a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f18082df-6672-48af-b0f9-533207b4f4a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

