### PR TITLE
Fix rename dry-run output and webm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ midnite-archive rename severo12/videos
 | `-d, --dry-run`    | Preview changes without renaming                          |
 | `-r, --recursive`  | Process subdirectories recursively                        |
 | `-v, --verbose`    | Show each rename operation                                |
-| `-e, --extensions` | File extensions to process (default: mkv mp4 description) |
+| `-e, --extensions` | File extensions to process (default: mkv mp4 webm description) |
 
 ## Development
 

--- a/docs/cli-ux.md
+++ b/docs/cli-ux.md
@@ -122,8 +122,8 @@ With `-v`, expect list parsing and per-video previews as `INFO` lines.
 
 **Behavior notes:**
 
-- Dry-run builds a source → renamed table.
-- Today the table is emitted via tracing (`INFO`), so **dry-run is easiest to see with `-v`** until stdout is unified.
+- Dry-run prints a source → renamed table on stdout without modifying files.
+- Default extensions are `mkv`, `mp4`, `webm`, and `description`.
 
 ## Error shape
 
@@ -138,6 +138,6 @@ Exit code `1`. Prefer actionable messages (missing yt-dlp/deno, bad path, invali
 Tracked here so future CLI changes stay aligned with this spec:
 
 - [ ] Make `download` / `comments` summaries as informative as `generate` (paths + counts on stdout by default).
-- [ ] Print `rename` dry-run table on stdout (not only via `-v` tracing).
+- [x] Print `rename` dry-run table on stdout (not only via `-v` tracing).
 - [ ] Align status ornaments (`✓` vs stats emoji) under one style.
 - [ ] Prefer channel display without forcing `@` when the input is a `UC…` channel id.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -53,7 +53,7 @@ pub enum Commands {
         #[arg(short, long, action = clap::ArgAction::SetTrue)]
         dry_run: bool,
         /// File extensions to process
-        #[arg(short = 'e', long, default_values = ["mkv", "mp4", "description"])]
+        #[arg(short = 'e', long, default_values = ["mkv", "mp4", "webm", "description"])]
         extensions: Vec<String>,
     },
 }

--- a/src/cli/rename.rs
+++ b/src/cli/rename.rs
@@ -33,14 +33,17 @@ pub fn execute(
 
     if renames.is_empty() {
         tracing::info!("No files to rename.");
+        println!("✓ No files to rename.");
         return Ok(());
     }
 
     if dry_run {
         display_rename_table(&renames);
         tracing::info!("Dry run complete. Would rename {} files.", renames.len());
+        println!("Dry run: would rename {} file(s).", renames.len());
     } else {
         let mut success_count = 0;
+        let mut failure_count = 0;
         for (source_path, new_name) in &renames {
             let new_path = source_path.parent().unwrap().join(new_name);
             let final_path = handle_conflict(&new_path);
@@ -56,10 +59,16 @@ pub fn execute(
                 }
                 Err(e) => {
                     tracing::error!("Error renaming {}: {}", source_path.display(), e);
+                    eprintln!("Error renaming {}: {}", source_path.display(), e);
+                    failure_count += 1;
                 }
             }
         }
         tracing::info!("Renamed {} files.", success_count);
+        println!("✓ Renamed {} file(s).", success_count);
+        if failure_count > 0 {
+            bail!("Failed to rename {} file(s)", failure_count);
+        }
     }
 
     Ok(())
@@ -125,7 +134,7 @@ fn display_rename_table(renames: &RenameList) {
         table.add_row(vec![&source_name, new_name]);
     }
 
-    tracing::info!("\n{table}");
+    println!("{table}");
 }
 
 fn sanitize_filename(path: &Path, re: &Regex, underscore_re: &Regex) -> String {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `midnite-archive rename -d ...` appearing to do nothing when verbosity is off.

### Root cause
The dry-run table and summaries were emitted exclusively via `tracing::info!`, while the default tracing level is `off`. The command succeeded silently.

### Changes
- Print dry-run table and result summaries to stdout without requiring `-v`
- Print an explicit “No files to rename” result
- Report per-file rename failures and return a non-zero error if any fail
- Add `webm` to default extensions (yt-dlp commonly outputs WebM)
- Update README and CLI UX spec

### Verification
- `cargo test`: 25 passed
- `cargo clippy -- -D warnings`: passed
- End-to-end dry-run displayed both `.webm` and `.description` candidates without modifying them
- End-to-end actual rename renamed both files and printed a summary
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f18082df-6672-48af-b0f9-533207b4f4a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f18082df-6672-48af-b0f9-533207b4f4a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

