### PR TITLE
Improve Dependabot config for quieter, safer updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
       day: "monday"
       time: "06:00"
     open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
     cooldown:
       default-days: 7
     groups:
@@ -26,8 +24,6 @@ updates:
       day: "monday"
       time: "06:00"
     open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
     cooldown:
       default-days: 7
       semver-patch-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,18 +3,40 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
       time: "06:00"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
     cooldown:
       default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
       time: "06:00"
-    target-branch: "main"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
     cooldown:
       default-days: 7
+      semver-patch-days: 3
+      semver-minor-days: 7
+      semver-major-days: 30
+    groups:
+      rust-deps:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `.github/dependabot.yml` to reduce PR noise and tighten update timing for Cargo and GitHub Actions.

- Switch schedule from daily to weekly (Monday 06:00)
- Cap `open-pull-requests-limit` at 5 for both ecosystems
- Group minor/patch updates; majors stay as separate PRs
- Keep Actions cooldown at 7 days; add SemVer-aware Cargo cooldowns (patch 3 / minor 7 / major 30)
- Drop cargo-only `target-branch` so both entries use the repo default
- Rely on Dependabot’s default `dependencies` label (no explicit `labels` config)

PoC directories are intentionally left out of scope.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c083d4b8-befb-4e21-90f9-56a83f2d78ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c083d4b8-befb-4e21-90f9-56a83f2d78ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

