### PR TITLE
docs: approve ytd-rs 0.2.1 MIT license (#65)

### DIFF
--- a/docs/yt-dlp-integration.md
+++ b/docs/yt-dlp-integration.md
@@ -58,9 +58,9 @@ selection.
 - Crate: <https://crates.io/crates/ytd-rs>
 - Source: <https://github.com/narrrl/ytd-rs>
 - Reviewed version: `0.2.1`
-- License: repository README states `MIT`; crates.io reports the license field
-  as non-standard, so package metadata should be clarified upstream before
-  adoption.
+- License: **MIT** (see [License decision](#license-decision-ytd-rs-021) below).
+  crates.io still shows `non-standard` / `unknown` because the crate uses
+  `license-file = "LICENSE"` instead of SPDX `license = "MIT"`.
 
 A smaller asynchronous wrapper with a builder API, structured metadata, custom
 yt-dlp argument passthrough, line-by-line process output, and binary streaming.
@@ -71,8 +71,8 @@ yt-dlp must already be available on `PATH`.
 - Custom arguments preserve access to all current yt-dlp features.
 - Streaming process output is a direct path to CLI and TUI progress events.
 - Small API and dependency footprint.
-- MIT terms are compatible with a permissively licensed midnite-archive, once
-  the crates.io metadata discrepancy is resolved.
+- MIT terms are compatible with midnite-archive distribution (confirmed;
+  crates.io metadata discrepancy is cosmetic — see License decision).
 - Keeps dependency installation separate from download orchestration.
 
 **Concerns**
@@ -96,8 +96,33 @@ yt-dlp must already be available on `PATH`.
 | Progress foundation | Typed hooks | Streamed output lines |
 | Installs yt-dlp/ffmpeg | Yes | No |
 | Current archive/comments parity | Must be proven | Likely via custom args; must be proven |
-| License impact | Requires GPL-compatible project distribution | MIT stated upstream; metadata needs confirmation |
+| License impact | Requires GPL-compatible project distribution | MIT terms confirmed; crates.io metadata cosmetic only |
 | Integration size | Larger, opinionated API | Smaller wrapper |
+
+## License decision (`ytd-rs` 0.2.1)
+
+Issue: [#65](https://github.com/lbrealdev/midnite-archive/issues/65)  
+Checked: 2026-07-25
+
+| Source | Finding |
+|--------|---------|
+| Upstream [`LICENSE`](https://github.com/narrrl/ytd-rs/blob/main/LICENSE) | Standard MIT text (`Copyright (c) 2021 Nils`) |
+| Published crate `ytd-rs` 0.2.1 tarball | Includes `LICENSE` (same MIT text) |
+| Upstream / crate `Cargo.toml` | `license-file = "LICENSE"` (no SPDX `license` field) |
+| crates.io API / `cargo info` | License reported as `non-standard` / `unknown` |
+
+**Decision: approve `ytd-rs` 0.2.1 for production adoption from a licensing
+perspective.** MIT terms are compatible with midnite-archive distribution. The
+crates.io `unknown` / `non-standard` label is a metadata packaging issue, not a
+rights issue: Cargo treats `license-file` as a non-SPDX custom license for
+registry display even when the file is MIT.
+
+**Upstream follow-up (optional, non-blocking):** ask
+[narrrl/ytd-rs](https://github.com/narrrl/ytd-rs) to set `license = "MIT"` (and
+keep or drop `license-file`) so crates.io shows SPDX MIT. Do not block `#66` on
+that change.
+
+Spike criterion #9 is satisfied by this decision.
 
 ## Recommendation
 
@@ -151,7 +176,8 @@ The preferred candidate must demonstrate all of the following before replacing
 8. Work with externally installed yt-dlp/ffmpeg on Linux, with a documented
    path for macOS and Windows packaging.
 9. Confirm the selected crate's license metadata and compatibility before
-   merging the dependency.
+   merging the dependency. **Done (2026-07-25):** MIT confirmed; see
+   [License decision](#license-decision-ytd-rs-021).
 
 ## Dependency health checks
 

--- a/poc/RESULTS.md
+++ b/poc/RESULTS.md
@@ -31,8 +31,22 @@ Test URL: `https://www.youtube.com/watch?v=jNQXAC9IVRw` (“Me at the zoo”)
 | Live YouTube fetch (cloud) | blocked (bot check) | blocked (bot check) |
 | Live YouTube fetch (local) | **pass** (full download) | **fail** (claimed success, empty out) |
 | License (repo file) | MIT (`LICENSE`) | GPL-3.0-only |
-| License (crates.io metadata) | `unknown` | `GPL-3.0-only` |
+| License (crates.io metadata) | `non-standard` / `unknown` (uses `license-file`) | `GPL-3.0-only` |
 | Latest crates.io usability | ok | **2.7.x fails resolve** (`lofty` 0.23.2/0.23.3 yanked); PoC pinned `=2.1.0` |
+
+## License decision (`ytd-rs` 0.2.1) — 2026-07-25
+
+Issue: [#65](https://github.com/lbrealdev/midnite-archive/issues/65)
+
+Re-checked crates.io + the published `0.2.1` crate tarball:
+
+- `LICENSE` inside the crate is standard MIT (`Copyright (c) 2021 Nils`).
+- `Cargo.toml` uses `license-file = "LICENSE"` rather than SPDX `license = "MIT"`,
+  which is why crates.io / `cargo info` report `non-standard` / `unknown`.
+- **Approved for production dependency adoption.** Metadata mismatch is cosmetic;
+  optional upstream fix is to publish with `license = "MIT"`.
+
+See also [`docs/yt-dlp-integration.md`](../docs/yt-dlp-integration.md#license-decision-ytd-rs-021).
 
 ## Notes
 
@@ -43,7 +57,7 @@ Test URL: `https://www.youtube.com/watch?v=jNQXAC9IVRw` (“Me at the zoo”)
 - Progress is raw stdout lines — fine for CLI/TUI after light parsing.
 - Local run confirmed EJS/Deno + `--write-description` + real download output.
 - Does not manage binaries; Linux/macOS/Windows packaging must install yt-dlp/ffmpeg (and Deno for EJS) separately.
-- Clarify crates.io license metadata with upstream (repo LICENSE is MIT).
+- License: MIT confirmed in published crate; crates.io `unknown` is `license-file` metadata only (#65 closed with adopt decision).
 
 ### `boul2gom/yt-dlp`
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #65. Confirms `ytd-rs` 0.2.1 is safe to ship as a production dependency from a licensing perspective, and records the decision in the migration docs.

## Findings (2026-07-25)

| Source | Result |
|--------|--------|
| Upstream `LICENSE` | Standard MIT (`Copyright (c) 2021 Nils`) |
| Published crate tarball `0.2.1` | Includes the same `LICENSE` |
| `Cargo.toml` | `license-file = "LICENSE"` (no SPDX `license` field) |
| crates.io / `cargo info` | `non-standard` / `unknown` |

**Decision:** approve adoption. The crates.io label is cosmetic (`license-file` vs SPDX `license = "MIT"`), not a rights problem. Optional non-blocking upstream ask: publish with `license = "MIT"`.

## Changes

- [`docs/yt-dlp-integration.md`](docs/yt-dlp-integration.md) — License decision section; spike criterion #9 marked done
- [`poc/RESULTS.md`](poc/RESULTS.md) — same decision + matrix note

Does **not** add `ytd-rs` to the main `Cargo.toml` (that remains #66).

## Test plan

- [x] crates.io API + published crate tarball inspected
- [x] Upstream LICENSE fetched and compared
- [x] Maintainer: skim decision section; merge unblocks #66

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d1bb9a9-961a-4967-a8c4-aa649dcf481e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d1bb9a9-961a-4967-a8c4-aa649dcf481e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

